### PR TITLE
LastInc now writes "completed" to "status-inc-backup"-file already after...

### DIFF
--- a/ibex-backup.py
+++ b/ibex-backup.py
@@ -434,8 +434,8 @@ def incBackup(incType, copy=True, offsite=True):
         status = runCommand(command)
         if status == 1:
             return 1
-	else:
-	    setStatus(incStatusFile, 'completed')
+        else:
+           setStatus(incStatusFile, 'completed')
 
         if offsite:
             logging.info('Moving archive to offsite location')


### PR DESCRIPTION
... having suceeded with tar/bz2:ing the database file. Before this change, "completed" was written to the status-file only upon a successful file transfer to the online storage. In conclusion, this change ensures that the next incremental backup (FirstInc) can be performed even though the tar.bz2-file is currently being transferred to the online storage.
